### PR TITLE
Fix gender option value mismatch

### DIFF
--- a/src/features/register/RegisterForm.tsx
+++ b/src/features/register/RegisterForm.tsx
@@ -51,7 +51,7 @@ const RegisterForm = () => {
   const genderOptions: GenderOption[] = [
     { value: 'male', label: 'Male' },
     { value: 'female', label: 'Female' },
-    { value: 'others', label: 'Others' },
+    { value: 'other', label: 'Others' },
   ];
 
   const onSubmit: SubmitHandler<RegisterRequest> = async (formData) => {


### PR DESCRIPTION
## Summary
- correct gender option value in registration form to match API schema

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864c02e14348330803a9c568b017b21