### PR TITLE
Fix admin article request imports

### DIFF
--- a/src/app/api/admin/articles/create-article/route.ts
+++ b/src/app/api/admin/articles/create-article/route.ts
@@ -1,10 +1,10 @@
 import {
-  AdminCreateArticleRequest,
   Created,
   InternalServerError,
   UnAuthorizedError,
   ValidationError,
 } from '@/api/client';
+import { AdminCreateArticleRequest } from '@/lib/zod/admin/article-management/article';
 import { prisma } from '@/lib/prisma';
 import { authorizeAdmin } from '@/lib/utils/authorize-admin';
 import { adminCreateArticleSchema } from '@/lib/zod/admin/article-management/article';

--- a/src/app/api/admin/articles/update-article/route.ts
+++ b/src/app/api/admin/articles/update-article/route.ts
@@ -1,10 +1,10 @@
 import {
-  AdminUpdateArticleRequest,
   InternalServerError,
   Success,
   UnAuthorizedError,
   ValidationError,
 } from '@/api/client';
+import { AdminUpdateArticleRequest } from '@/lib/zod/admin/article-management/article';
 import { prisma } from '@/lib/prisma';
 import { authorizeAdmin } from '@/lib/utils/authorize-admin';
 import { adminUpdateArticleSchema } from '@/lib/zod/admin/article-management/article';

--- a/src/lib/zod/admin/article-management/article.ts
+++ b/src/lib/zod/admin/article-management/article.ts
@@ -27,6 +27,8 @@ export const adminCreateArticleSchema = z.object({
   tags: z.array(z.string()).optional(),
 });
 
+export type AdminCreateArticleRequest = z.infer<typeof adminCreateArticleSchema>;
+
 // Define the Zod schema for updating an existing article by admin
 export const adminUpdateArticleSchema = z.object({
   id: z.number().int('Article ID must be an integer'),
@@ -59,3 +61,5 @@ export const adminUpdateArticleSchema = z.object({
   categoryId: z.number().int('Category ID must be an integer').optional(),
   tags: z.array(z.string()).optional(),
 });
+
+export type AdminUpdateArticleRequest = z.infer<typeof adminUpdateArticleSchema>;


### PR DESCRIPTION
## Summary
- add `AdminCreateArticleRequest` and `AdminUpdateArticleRequest` types
- update admin article routes to import new types

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f69675e90833080c6f033bccde1bb