### PR TITLE
Add Jest testing setup

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const config: JestConfigWithTsJest = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "db:reset": "DATABASE_URL='postgresql://postgres:password@localhost:5432/xincere_blog?schema=public' sh -c 'npx prisma migrate reset --skip-generate && npx prisma db seed'",
     "generate:client": "openapi-generator-cli generate -g typescript-axios -i ./src/api/specs/swagger.yaml -o ./src/api/client",
     "prepare": "husky install",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "jest"
   },
   "lint-staged": {
     "*.{ts,tsx}": "prettier --write",
@@ -81,6 +81,7 @@
     "@tailwindcss/postcss": "^4.1.8",
     "@tailwindcss/typography": "^0.5.16",
     "@types/bcrypt": "^5.0.2",
+    "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.19.0",
     "@types/nodemailer": "^6.4.17",
@@ -99,11 +100,13 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "husky": "^9.1.7",
+    "jest": "^30.0.4",
     "postcss": "^8.5.4",
     "prettier": "^3.5.3",
     "prisma": "^6.9.0",
     "prisma-erd-generator": "^2.0.4",
     "tailwindcss": "^4.1.8",
+    "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.8.3"

--- a/src/lib/zod/comment/comment.ts
+++ b/src/lib/zod/comment/comment.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const commentQuerySchema = z.object({
+  articleId: z.coerce
+    .number()
+    .int()
+    .positive({ message: 'articleId must be a positive integer' }),
+  skip: z.coerce.number().min(0).default(0),
+  take: z.coerce.number().min(1).max(100).default(5),
+});

--- a/tests/commentSchema.test.ts
+++ b/tests/commentSchema.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from '@jest/globals';
+import { commentQuerySchema } from '../src/lib/zod/comment/comment';
+import { skipPaginationSchema } from '../src/lib/zod/common/common';
+import { adminCreateCategorySchema } from '../src/lib/zod/admin/category-management/category';
+
+describe('commentQuerySchema', () => {
+  test('parses valid query', () => {
+    const parsed = commentQuerySchema.parse({
+      articleId: 1,
+      skip: '2',
+      take: '5',
+    });
+    expect(parsed).toEqual({ articleId: 1, skip: 2, take: 5 });
+  });
+
+  test('fails with invalid articleId', () => {
+    expect(() => commentQuerySchema.parse({ articleId: 0 })).toThrow();
+  });
+});
+
+describe('skipPaginationSchema', () => {
+  test('uses defaults when values missing', () => {
+    const parsed = skipPaginationSchema.parse({});
+    expect(parsed).toEqual({ skip: 0, take: 5 });
+  });
+});
+
+describe('adminCreateCategorySchema', () => {
+  test('fails when name missing', async () => {
+    await expect(
+      adminCreateCategorySchema.parseAsync({
+        slug: 'slug',
+        description: 'desc',
+      })
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with ts-jest
- add Zod schema for comment queries
- provide example tests for commentQuerySchema and existing schemas
- hook `npm test` to run Jest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f6893325c83309f84c995f91f8ea4