### PR TITLE
Fix verification URL and type references

### DIFF
--- a/src/app/api/admin/articles/create-article/route.ts
+++ b/src/app/api/admin/articles/create-article/route.ts
@@ -1,5 +1,4 @@
 import {
-  AdminCreateArticleRequest,
   Created,
   InternalServerError,
   UnAuthorizedError,
@@ -10,6 +9,8 @@ import { authorizeAdmin } from '@/lib/utils/authorize-admin';
 import { adminCreateArticleSchema } from '@/lib/zod/admin/article-management/article';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+
+type AdminCreateArticleRequest = z.infer<typeof adminCreateArticleSchema>;
 
 type CreateResponse =
   | UnAuthorizedError

--- a/src/app/api/admin/articles/delete-article/route.ts
+++ b/src/app/api/admin/articles/delete-article/route.ts
@@ -1,5 +1,4 @@
 import {
-  AdminDeleteArticlesRequest,
   InternalServerError,
   Success,
   UnAuthorizedError,
@@ -10,6 +9,8 @@ import { authorizeAdmin } from '@/lib/utils/authorize-admin';
 import { validateIDsSchema } from '@/lib/zod/common/common';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+
+type AdminDeleteArticlesRequest = z.infer<typeof validateIDsSchema>;
 
 type DeleteResponse =
   | UnAuthorizedError

--- a/src/app/api/admin/articles/get-arcticle/route.ts
+++ b/src/app/api/admin/articles/get-arcticle/route.ts
@@ -1,6 +1,4 @@
 import {
-  AdminGetArticlesRequest,
-  AdminGetArticles200Response,
   InternalServerError,
   UnAuthorizedError,
   ValidationError,
@@ -11,16 +9,9 @@ import { paginationWithSearchSchema } from '@/lib/zod/common/common';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
-export async function POST(
-  req: Request
-): Promise<
-  NextResponse<
-    | AdminGetArticles200Response
-    | ValidationError
-    | InternalServerError
-    | UnAuthorizedError
-  >
-> {
+type AdminGetArticlesRequest = z.infer<typeof paginationWithSearchSchema>;
+
+export async function POST(req: Request): Promise<NextResponse> {
   try {
     const adminAuthError = await authorizeAdmin();
     if (adminAuthError) return adminAuthError;

--- a/src/app/api/admin/articles/update-article/route.ts
+++ b/src/app/api/admin/articles/update-article/route.ts
@@ -1,5 +1,4 @@
 import {
-  AdminUpdateArticleRequest,
   InternalServerError,
   Success,
   UnAuthorizedError,
@@ -11,6 +10,8 @@ import { adminUpdateArticleSchema } from '@/lib/zod/admin/article-management/art
 import { ArticleStatus } from '@prisma/client';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+
+type AdminUpdateArticleRequest = z.infer<typeof adminUpdateArticleSchema>;
 
 export async function PUT(
   req: Request

--- a/src/app/api/admin/users/create-user/route.ts
+++ b/src/app/api/admin/users/create-user/route.ts
@@ -66,7 +66,7 @@ export async function POST(
       data: { emailVerificationToken: verificationToken },
     });
 
-    const verificationUrl = `${process.env.NEXTAUTH_URL}/auth/verify-email?token=${verificationToken}`;
+    const verificationUrl = `${process.env.NEXT_PUBLIC_API_URL}/auth/verify-email?token=${verificationToken}`;
 
     const emailResponse = await sendEmail({
       from: process.env.SMTP_USERNAME,


### PR DESCRIPTION
## Summary
- correct verification URL environment variable
- remove missing type imports and replace with zod inference
- format admin article route

## Testing
- `npm run build` *(fails: Object literal may only specify known properties)*

------
https://chatgpt.com/codex/tasks/task_e_686f68860b948330821cd44389258b41